### PR TITLE
Standardize Open Large Card Modal button styles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ function App() {
         {/* Demo Button for Card Large */}
         <button
           onClick={() => setShowCardLarge(true)}
-          className="bg-bg-primary-button text-text-contrast px-button-lg-x py-button-lg-y rounded-button font-600 text-sm hover:opacity-90 transition-opacity"
+          className="min-h-11 flex flex-row flex-wrap justify-center items-center bg-bg-primary-button px-button-lg-x py-button-lg-y rounded-button text-text-contrast font-600 text-sm"
         >
           Open Large Card Modal
         </button>


### PR DESCRIPTION
## Purpose
Ensure the "Open Large Card Modal" button follows the same styling conventions as other primary buttons throughout the project for visual consistency.

## Code changes
- Updated the button className to include standardized layout properties (`min-h-11 flex flex-row flex-wrap justify-center items-center`)
- Removed hover effect (`hover:opacity-90 transition-opacity`) to match other primary buttons
- Reordered CSS classes for better organization while maintaining the same visual appearanceTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c83a9f0092bd42d6bcfabb46b00e521f/nova-garden)

👀 [Preview Link](https://c83a9f0092bd42d6bcfabb46b00e521f-nova-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c83a9f0092bd42d6bcfabb46b00e521f</projectId>-->
<!--<branchName>nova-garden</branchName>-->